### PR TITLE
Rev transient dependency quick_xml as version in place causes future warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
  "num",
  "num-bigint",
  "num-traits",
- "quick-xml 0.28.2",
+ "quick-xml",
  "rand",
  "regex",
  "serde",
@@ -573,7 +573,7 @@ dependencies = [
  "gents",
  "gents_derives",
  "logisheets_workbook_derives",
- "quick-xml 0.28.2",
+ "quick-xml",
  "regex",
  "serde",
  "serde_json",
@@ -811,16 +811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
-dependencies = [
- "memchr",
- "serde",
 ]
 
 [[package]]
@@ -1340,7 +1330,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 name = "xmldiff"
 version = "0.3.0"
 dependencies = [
- "quick-xml 0.22.0",
+ "quick-xml",
 ]
 
 [[package]]
@@ -1352,7 +1342,7 @@ dependencies = [
  "convert_case",
  "linked-hash-map",
  "paste",
- "quick-xml 0.28.2",
+ "quick-xml",
  "regex",
  "serde",
  "serde_json",

--- a/crates/xmldiff/Cargo.toml
+++ b/crates/xmldiff/Cargo.toml
@@ -8,4 +8,4 @@ description = "compare 2 .xml files and show their differences"
 repository = "https://github.com/proclml/LogiSheets/crates/xmldiff"
 
 [dependencies]
-quick-xml = {version = "0.22.0", features = ["serialize"]}
+quick-xml = { version = "0.28", features = ["serialize"] }


### PR DESCRIPTION
I use xmldiff for testing but getting warnings related to the older quick_xml dependency so updated it to use quick_xml 0.28.  I'm currently using a fork with attribution but would love to just use the OSS lib.

Most definitely want to bump up the version of the xmldiff crate but I didn't here as I didn't want to mess with the bazil lock - will do so if this is something you'd accept.